### PR TITLE
Use event filters to read logs from a wider range

### DIFF
--- a/apps/web/src/hooks/useDelegationInfo.test.tsx
+++ b/apps/web/src/hooks/useDelegationInfo.test.tsx
@@ -28,8 +28,9 @@ describe('useDelegationInfo', () => {
   const mockAddress: Address = '0x1234567890123456789012345678901234567890'
   const mockPublicClient = {
     multicall: vi.fn(),
-    getLogs: vi.fn(),
     readContract: vi.fn(),
+    createContractEventFilter: vi.fn(),
+    getFilterLogs: vi.fn(),
   } as unknown as PublicClient
 
   beforeEach(() => {
@@ -56,7 +57,7 @@ describe('useDelegationInfo', () => {
       { result: BigInt(500) },
     ]
     mockPublicClient.multicall.mockResolvedValue(mockMulticallResult)
-    mockPublicClient.getLogs.mockResolvedValue([])
+    mockPublicClient.getFilterLogs.mockResolvedValue([])
 
     const { result } = renderHook(() => useDelegationInfo(mockAddress))
     const resolvedResult = await result.current.data()
@@ -78,7 +79,7 @@ describe('useDelegationInfo', () => {
       { result: BigInt(500) },
     ]
     mockPublicClient.multicall.mockResolvedValue(mockMulticallResult)
-    mockPublicClient.getLogs.mockResolvedValue([])
+    mockPublicClient.getFilterLogs.mockResolvedValue([])
 
     const { result } = renderHook(() => useDelegationInfo(mockAddress))
     const resolvedResult = await result.current.data()
@@ -100,7 +101,7 @@ describe('useDelegationInfo', () => {
       { result: BigInt(500) },
     ]
     mockPublicClient.multicall.mockResolvedValue(mockMulticallResult)
-    mockPublicClient.getLogs.mockResolvedValue([
+    mockPublicClient.getFilterLogs.mockResolvedValue([
       { args: { ids: [BigInt(1), BigInt(2)] } },
     ])
     mockPublicClient.readContract.mockResolvedValue([BigInt(100), BigInt(200)])

--- a/apps/web/src/hooks/useDelegationInfo.ts
+++ b/apps/web/src/hooks/useDelegationInfo.ts
@@ -79,9 +79,10 @@ async function getDelegatesFromEventLogs(
   client: PublicClient,
   address: Address
 ): Promise<DelegateApiResponse[]> {
-  const transferBatchedLogs = await client.getLogs({
+  const transferBatchedFilter = await client.createContractEventFilter({
     address: erc20MultiDelegateContract.address,
-    event: erc20MultiDelegateContract.abi[16],
+    abi: erc20MultiDelegateContract.abi,
+    eventName: 'TransferBatch',
     args: {
       to: address,
     },
@@ -89,14 +90,23 @@ async function getDelegatesFromEventLogs(
     toBlock: 'latest',
   })
 
-  const _transferSingleLogs = await client.getLogs({
+  const transferBatchedLogs = await client.getFilterLogs({
+    filter: transferBatchedFilter,
+  })
+
+  const transferSingleFilter = await client.createContractEventFilter({
     address: erc20MultiDelegateContract.address,
-    event: erc20MultiDelegateContract.abi[17],
+    abi: erc20MultiDelegateContract.abi,
+    eventName: 'TransferSingle',
     args: {
       to: address,
     },
     fromBlock: BigInt(erc20MultiDelegateContract.deployedBock),
     toBlock: 'latest',
+  })
+
+  const _transferSingleLogs = await client.getFilterLogs({
+    filter: transferSingleFilter,
   })
 
   const transferSingleLogs = _transferSingleLogs


### PR DESCRIPTION
Alchemy requests on the frontend started failing with "You can make eth_getLogs requests with up to a 500 block range". We can work around that in 2 ways:
1. Use the indexer already included in this repo. Probably the best long-term solution, but it requires us to host a server.
2. Optimize the RPC requests to fetch logs using event filters.

2 solves it for now.